### PR TITLE
The 4th variable of PyModuleDef is an int, not a pointer:

### DIFF
--- a/curve25519module.c
+++ b/curve25519module.c
@@ -158,7 +158,7 @@ curve25519_functions[] = {
         PyModuleDef_HEAD_INIT,
         "axolotl_curve25519",
         NULL,
-        NULL,
+        0,
         curve25519_functions,
     };
 


### PR DESCRIPTION
https://docs.python.org/3/c-api/module.html#c.PyModuleDef

Fixes compilation with clang.